### PR TITLE
Pass OS_REGION_NAME if set

### DIFF
--- a/neutron/delete_orphan_floatingips.py
+++ b/neutron/delete_orphan_floatingips.py
@@ -20,6 +20,9 @@ def main():
         tenant_name = os.environ['OS_TENANT_NAME']
         password = os.environ['OS_PASSWORD']
         auth_url = os.environ['OS_AUTH_URL']
+        region_name = None
+        if 'OS_REGION_NAME' in os.environ:
+            region_name = os.environ['OS_REGION_NAME']
     except KeyError:
         print("You need to source your openstack creds file first!")
         sys.exit(1)
@@ -27,7 +30,8 @@ def main():
     neutron = client.Client(username=username,
                             tenant_name=tenant_name,
                             password=password,
-                            auth_url=auth_url)
+                            auth_url=auth_url,
+                            region_name=region_name)
 
     floatingips = neutron.list_floatingips()
     for floatingip in floatingips['floatingips']:

--- a/neutron/delete_tenantless_floatingips.py
+++ b/neutron/delete_tenantless_floatingips.py
@@ -20,6 +20,9 @@ def main():
         tenant_name = os.environ['OS_TENANT_NAME']
         password = os.environ['OS_PASSWORD']
         auth_url = os.environ['OS_AUTH_URL']
+        region_name = None
+        if 'OS_REGION_NAME' in os.environ:
+            region_name = os.environ['OS_REGION_NAME']
     except KeyError:
         print("You need to source your openstack creds file first!")
         sys.exit(1)
@@ -27,12 +30,14 @@ def main():
     neutron = client.Client(username=username,
                             tenant_name=tenant_name,
                             password=password,
-                            auth_url=auth_url)
+                            auth_url=auth_url,
+                            region_name=region_name)
 
     keystone = ksclient.Client(username=username,
                             tenant_name=tenant_name,
                             password=password,
-                            auth_url=auth_url)
+                            auth_url=auth_url,
+                            region_name=region_name)
 
     floatingips = neutron.list_floatingips()
     for floatingip in floatingips['floatingips']:

--- a/neutron/listorphans.py
+++ b/neutron/listorphans.py
@@ -15,6 +15,8 @@ def get_credentials():
     d['password'] = os.environ['OS_PASSWORD']
     d['auth_url'] = os.environ['OS_AUTH_URL']
     d['tenant_name'] = os.environ['OS_TENANT_NAME']
+    if 'OS_REGION_NAME' in os.environ:
+        d['region_name'] = os.environ['OS_REGION_NAME']
     return d
 
 credentials = get_credentials()


### PR DESCRIPTION
We have a multi-region cloud, and need to pass the correct region when talking to the OpenStack API.  Typically we use the OS_REGION_NAME environment variable.  I have tested the code with these modifications, and both with OS_REGION_NAME set and without it.
