### PR TITLE
Fix --noop condition

### DIFF
--- a/libvirt/cleanup-orphaned-vms.sh
+++ b/libvirt/cleanup-orphaned-vms.sh
@@ -22,11 +22,11 @@ for i in `virsh list --all | grep -E '^ [0-9-]+' | awk '{print $2;}'` ; do
     virsh dumpxml $i | grep "source file" | grep -E "$UUIDS" >/dev/null
     if [ $? -ne 0 ]; then
         echo -n "+ $i is NOT known to OpenStack, removing managedsave info... "
-        [ ! -z "$1" ] && virsh managedsave-remove $i 1>/dev/null 2>&1
+        [ -z "$1" ] && virsh managedsave-remove $i 1>/dev/null 2>&1
         echo -n "destroying VM... "
-        [ ! -z "$1" ] && virsh destroy $i 1>/dev/null 2>&1
+        [ -z "$1" ] && virsh destroy $i 1>/dev/null 2>&1
         echo -n "undefining VM... "
-        [ ! -z "$1" ] && virsh undefine $i 1>/dev/null 2>&1
+        [ -z "$1" ] && virsh undefine $i 1>/dev/null 2>&1
         echo DONE
     else
         echo "* $i is known to OpenStack, not removing."


### PR DESCRIPTION
[ ! -z "$1" ] execute code when an argument is defined. Remove ! into the condition to make --noop work properly